### PR TITLE
Install docker-py as part of the ansible playbook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,9 @@ script:
 
 notifications:
   email: false
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/
   irc:
-    - secure: "IkPCyARITsqJ84m0OZ9I3L72/JmXc+CKTdnnoJi8NIHkktIl0dk5faLKm/NyZOsaxELnfIEn1BSuZB9X/Rvtftg+Pd98WHA7eWtxCHkxEOaF5C6C5a5lGOTBSoTrAlAavz4fIDj+T06grpQqJ3mkmz/LaS1HY7eEekFe2jb/R6yuKfjB9Ix/fxU/T3oBlXbEuZBODMKc+cR/Eix1tAAFaZbjUoXj3GE7pj2VrRv+1LmG0LWYQHhSvD6V+u3I+SLUbq4w5OTD6sFsc41AP43wieukXhkOg08uRLeryLJsZSewJyUGwXBFBjGAcZjfxjURobmQZahdfL7CXGzPSQl+/Yjrx9RuW25R+BpRc8m5FgZAdLiGUrUGjt4pyt/wwLBdO9jeulfbL/4BVewallmJFTn/6jSRys5JyrcJHF8EvjTAfEwbiYt1t9brBfWkaj615feEGrsCY+YAjNliZ/rp80nb+WfzyN6vzwnBwYQaYglI5fzMwpFh/fkm0DjkTdUELtzFTIuFwC9uu2SOA24kmhDUIi5IwScoxVA+B0NG69jjOIeZ9+/LkMQQB+yQ0t6rJgYfM8y5F5DSO0iqDHFN+H7Y3I9ShlNqKWv2DnYWujGASKpYyQ6PROcvznQatmY3vARkY6QXAtP0WK6v7LU7YKrdOGGLFHwTr7/r/hhXhQk="
+    channels:
+      - secure: "IkPCyARITsqJ84m0OZ9I3L72/JmXc+CKTdnnoJi8NIHkktIl0dk5faLKm/NyZOsaxELnfIEn1BSuZB9X/Rvtftg+Pd98WHA7eWtxCHkxEOaF5C6C5a5lGOTBSoTrAlAavz4fIDj+T06grpQqJ3mkmz/LaS1HY7eEekFe2jb/R6yuKfjB9Ix/fxU/T3oBlXbEuZBODMKc+cR/Eix1tAAFaZbjUoXj3GE7pj2VrRv+1LmG0LWYQHhSvD6V+u3I+SLUbq4w5OTD6sFsc41AP43wieukXhkOg08uRLeryLJsZSewJyUGwXBFBjGAcZjfxjURobmQZahdfL7CXGzPSQl+/Yjrx9RuW25R+BpRc8m5FgZAdLiGUrUGjt4pyt/wwLBdO9jeulfbL/4BVewallmJFTn/6jSRys5JyrcJHF8EvjTAfEwbiYt1t9brBfWkaj615feEGrsCY+YAjNliZ/rp80nb+WfzyN6vzwnBwYQaYglI5fzMwpFh/fkm0DjkTdUELtzFTIuFwC9uu2SOA24kmhDUIi5IwScoxVA+B0NG69jjOIeZ9+/LkMQQB+yQ0t6rJgYfM8y5F5DSO0iqDHFN+H7Y3I9ShlNqKWv2DnYWujGASKpYyQ6PROcvznQatmY3vARkY6QXAtP0WK6v7LU7YKrdOGGLFHwTr7/r/hhXhQk="
+    on_success: "change"
+    on_failure: "change"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
  - sudo apt-get install -qq python-apt python-pycurl
 
 install:
-  - sudo pip install ansible docker-py
+  - sudo pip install ansible
   - echo -e 'localhost  ansible_connection=local' > tests/inventory
   - echo -e '[defaults]\nroles_path = ../\nhostfile = ./tests/inventory' > ansible.cfg
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,3 +34,18 @@
   retries: 5
   delay: 10
   until: result|success
+
+- name: 'Install python-pip'
+  apt:
+    name: 'python-pip'
+    state: 'present'
+
+- name: 'Install virtualenv'
+  pip:
+    name: 'virtualenv'
+    state: 'present'
+
+- name: 'Install docker-py'
+  pip:
+    name: 'docker-py'
+    state: 'present'


### PR DESCRIPTION
This is a needed component for all ansible-docker interaction so it's probably best to have the playbook install it, as well.
